### PR TITLE
Prevent multiple MLLP adapter instances from submitting metrics with the same label

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -137,11 +137,17 @@ go_repository(
     importpath = "github.com/google/go-cmp",
 )
 
+go_repository(
+    name = "com_github_google_uuid",
+    commit = "0e4e31197428a347842d152773b4cace4645ca25",
+    importpath = "github.com/google/uuid",
+)
+
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "dc97fccceacd4c6be14e800b2a00693d5e8d07f69ee187babfd04a80a9f8e250",
-    strip_prefix = "rules_docker-0.14.1",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.1/rules_docker-v0.14.1.tar.gz"],
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+    strip_prefix = "rules_docker-0.14.4",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
 )
 
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
@@ -151,6 +157,14 @@ _go_image_repos()
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
 
 container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 

--- a/shared/monitoring/BUILD.bazel
+++ b/shared/monitoring/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//shared/util:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@com_github_google_uuid//:go_default_library",
         "@com_github_googleapis_gax_go//:go_default_library",
         "@com_google_cloud_go//compute/metadata:go_default_library",
         "@com_google_cloud_go//monitoring/apiv3:go_default_library",

--- a/shared/monitoring/monitoring.go
+++ b/shared/monitoring/monitoring.go
@@ -28,6 +28,7 @@ import (
 	"cloud.google.com/go/monitoring/apiv3"
 	gax "github.com/googleapis/gax-go"
 	"google.golang.org/api/option"
+	"github.com/google/uuid"
 	"github.com/GoogleCloudPlatform/mllp/shared/util"
 
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
@@ -80,6 +81,11 @@ func ConfigureExport(ctx context.Context, cl *Client, cred string) error {
 		return err
 	}
 	cl.labels["job"] = "mllp_adapter"
+	// Use uuid to prevent multiple mllp adapter instances from submitting
+	// metrics with the same label.
+	id := uuid.New().String()
+	cl.labels["id"] = id
+	log.Infof(`Exporting stackdriver matrics with label "id"=%q`, id)
 	return nil
 }
 


### PR DESCRIPTION
Prevent multiple MLLP adapter instances from submitting metrics with the same label

When running multiple instances of MLLP adapter in the same VM instance, we could get the following error: "CreateTimeSeries failed: rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: Points must be written in order. One or more of the points specified had an older start time than the most recent point.: timeSeries[...]". This is because multiple MLLP adapter instances tried to submit metrics with the same label. Adding UUID to the label to prevent the possible collision.
