### PR TITLE
update MLLP adapter GKE configuration to use the v1 GKE api

### DIFF
--- a/config/mllp_adapter.yaml
+++ b/config/mllp_adapter.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mllp-adapter-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mllp-adapter
   template:
     metadata:
       labels:

--- a/config/mllp_adapter_e2e.yaml
+++ b/config/mllp_adapter_e2e.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mllp-adapter-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mllp-adapter
   template:
     metadata:
       labels:

--- a/config/presubmit/mllp_adapter_presubmit.yaml
+++ b/config/presubmit/mllp_adapter_presubmit.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mllp-adapter-presubmit-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mllp-adapter-presubmit
   template:
     metadata:
       labels:

--- a/mllp_adapter/docs/binary_authz.md
+++ b/mllp_adapter/docs/binary_authz.md
@@ -340,12 +340,15 @@ Sample deployment YAML file
 #   (form: gcr.io/cloud-healthcare-containers/mllp-adapter@${digest})
 # hl7_v2_project_id, hl7_v2_location_id, and other arguments are required for having the
 # MLLP adapter actually working, but not strictly necessary to be correct in this codelab.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mllp-adapter-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mllp-adapter
   template:
     metadata:
       labels:


### PR DESCRIPTION
update MLLP adapter GKE configuration to use the v1 GKE api
