### PR TITLE
Use InstanceID metadata instead of InstanceName for one of the metric labels. 

### DIFF
--- a/shared/monitoring/monitoring.go
+++ b/shared/monitoring/monitoring.go
@@ -76,7 +76,7 @@ func ConfigureExport(ctx context.Context, cl *Client, cred string) error {
 	if err != nil {
 		return err
 	}
-	cl.labels["instance"], err = metadata.InstanceName()
+	cl.labels["instance"], err = metadata.InstanceID()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use InstanceID metadata instead of InstanceName for one of the metric labels. 

When running a MLLP adapter on GKE, container is crashing with error: "failed to configure monitoring: metadata: GCE metadata "instance/name" not defined". This is because GKE pods don't have "name" property.
